### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -2,7 +2,10 @@ version: 2.1
 
 description: >
   Use the Oxygen open source framework to run automated tests.
-  See this orb's source: https://github.com/oxygenhq/oxygen-orb
+
+display:
+  source_url: https://github.com/oxygenhq/oxygen-orb
+  home_url: https://docs.oxygenhq.org/
 
 executors:
   default:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.